### PR TITLE
dismiss dialog

### DIFF
--- a/app/src/main/java/com/example/bibol/androidgitapp/MainActivity.java
+++ b/app/src/main/java/com/example/bibol/androidgitapp/MainActivity.java
@@ -39,7 +39,7 @@ public class MainActivity extends ActionBarActivity {
                 @Override
                 public void onSuccess(User user) {
                     // show user activity
-                    dialog.hide();
+                    dialog.dismiss();
                 }
 
                 @Override


### PR DESCRIPTION
`hide()` just hides dialog, doesn't `dismiss()` altogether.